### PR TITLE
Read all records or a selected batch of records at once

### DIFF
--- a/src/main/java/nl/knaw/dans/common/dbflib/Table.java
+++ b/src/main/java/nl/knaw/dans/common/dbflib/Table.java
@@ -16,11 +16,15 @@
  */
 package nl.knaw.dans.common.dbflib;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -625,7 +629,122 @@ public class Table
                      header.getVersion());
         memo.open(ifNonExistent);
     }
+    
+    private static final int DEFAULT_BUFFER_SIZE = 1000000;
+    private static final int DEFAULT_RECORD_ARRAY_LIST_SIZE = 10000;
+    private byte[] buffer = null;
+    private int startBufferedRecord = 0;
+    private int nBufferedRecord = 0;
+    
+    private void bufferRecords(final int startIndex, final int bufferSize) throws IOException {
+        if (buffer == null || startIndex < startBufferedRecord || startIndex >= startBufferedRecord + nBufferedRecord) {
+            startBufferedRecord = startIndex;
+            nBufferedRecord = Math.max(Math.min(bufferSize / header.getRecordLength(), header.getRecordCount() - startIndex + 1), 1);
+            final int allocatedBufferSize = nBufferedRecord * header.getRecordLength();
+            buffer = new byte[allocatedBufferSize];
+            jumpToRecordAt(startIndex);
+            raFile.read(buffer);
+        }
+    }
+    
+    /**
+     * Get a specified number of records starting at a given index.
+     * @param startIndex Index of the first record to be read
+     * @param nRecords Number of records to be read
+     * @param bufferSize Buffer size to be used to read each batch of records
+     * @param includeDeleted Include deleted records
+     * @return List of Record objects
+     * @throws IOException
+     * @throws CorruptedTableException 
+     */
+    public List<Record> getRecordsAt(final int startIndex, final int nRecords, final int bufferSize, final boolean includeDeleted) throws IOException, CorruptedTableException {
+        checkOpen();
+                
+        final ArrayList<Record> records = new ArrayList<Record>(DEFAULT_RECORD_ARRAY_LIST_SIZE);
+        
+        int currentRecord = startIndex;
+        DataInput dataInput = null;
+        while(currentRecord < header.getRecordCount() && currentRecord < startIndex + nRecords) {
+            if(currentRecord < startBufferedRecord || currentRecord >= startBufferedRecord + nBufferedRecord) {
+                bufferRecords(currentRecord, bufferSize);
+                dataInput = null;
+            }
+            if (dataInput == null) {
+                dataInput = new DataInputStream(new ByteArrayInputStream(buffer));
+            }
+            
+            final Record record = getRecord(dataInput);
+            if (includeDeleted || !record.isMarkedDeleted()) {
+                records.add(record);
+            }
+            currentRecord++;
+        }
+        
+        return records;
+    }
+    
+    /**
+     * Get a specified number of records starting at a given index.
+     * @param startIndex Index of the first record to be read
+     * @param nRecords Number of records to be read
+     * @param includeDeleted Include deleted records
+     * @return List of Record objects
+     * @throws IOException
+     * @throws CorruptedTableException 
+     */
+    public List<Record> getRecordsAt(final int startIndex, final int nRecords, boolean includeDeleted) throws IOException, CorruptedTableException {
+        return getRecordsAt(startIndex, nRecords, DEFAULT_BUFFER_SIZE, includeDeleted);
+    }
+    
+    /**
+     * Get a specified number of records starting at a given index. Deleted records are excluded.
+     * @param startIndex Index of the first record to be read
+     * @param nRecords Number of records to be read
+     * @return List of Record objects
+     * @throws IOException
+     * @throws CorruptedTableException 
+     */
+    public List<Record> getRecordsAt(final int startIndex, final int nRecords) throws IOException, CorruptedTableException {
+        return getRecordsAt(startIndex, nRecords, DEFAULT_BUFFER_SIZE, false);
+    }
+    
+    /**
+     * Get all records, specifying if deleted records should be included
+     * @param includeDeleted Include deleted records
+     * @param bufferSize Specified size of buffer used to read raw data
+     * @return List of Record objects
+     * @throws IOException
+     * @throws CorruptedTableException 
+     */
+    public List<Record> getAllRecords(final boolean includeDeleted, final int bufferSize) throws IOException, CorruptedTableException {
+        checkOpen();
+        return getRecordsAt(0, header.getRecordCount(), bufferSize, includeDeleted);
+    }
 
+    /**
+     * Get all non deleted records
+     * @param bufferSize Specified size of buffer used to read raw data
+     * @return List of Record objects
+     * @throws IOException
+     * @throws CorruptedTableException 
+     */
+    public List<Record> getAllRecords(final int bufferSize) throws IOException, CorruptedTableException {
+        checkOpen();
+        return getRecordsAt(0, header.getRecordCount(), bufferSize, false);
+    }
+
+    /**
+     * Get all non deleted records
+     * @return List of Record objects
+     * @throws IOException
+     * @throws CorruptedTableException 
+     */
+    public List<Record> getAllRecords() throws IOException, CorruptedTableException {
+        checkOpen();
+        return getRecordsAt(0, header.getRecordCount(), DEFAULT_BUFFER_SIZE, false);
+    }
+    
+    
     /**
      * Returns the record at index. If the index points to a record beyond the last a
      * {@link NoSuchElementException} is thrown. Attention: records marked as deleted <em>are</em>
@@ -647,23 +766,38 @@ public class Table
         }
 
         jumpToRecordAt(index);
+        
+        /* Read one record worth of raw data and construct a
+           ByteArrayInputStream backed by a byte array */
+        byte[] buffer = new byte[header.getRecordLength()];
+        raFile.read(buffer);
+        DataInput dataInput = new DataInputStream(new ByteArrayInputStream(buffer));
+        
+        try {
+            return getRecord(dataInput);
+        } catch (NoSuchElementException ex) {
+            throw new NoSuchElementException(String.format("Invalid index: %d", index));
+        }
+    }
+    
+    Record getRecord(DataInput dataInput) throws IOException, CorruptedTableException {
 
-        final byte firstByteOfRecord = raFile.readByte();
-
+        final byte firstByteOfRecord = dataInput.readByte();
+        
         /*
          * This should actually not be possible, as we already checked the index against the record
          * count. Checking anyway to be on the safe side.
          */
         if (firstByteOfRecord == MARKER_EOF)
         {
-            throw new NoSuchElementException(String.format("Invalid index: %d", index));
+            throw new NoSuchElementException();
         }
 
         final Map<String, Value> recordValues = new HashMap<String, Value>();
 
         for (final Field field : header.getFields())
         {
-            final byte[] rawData = Util.readStringBytes(raFile,
+            final byte[] rawData = Util.readStringBytes(dataInput,
                                                         field.getLength());
 
             switch (field.getType())
@@ -714,7 +848,7 @@ public class Table
             }
         }
 
-        return new Record(firstByteOfRecord == MARKER_RECORD_DELETED, recordValues);
+        return new Record(firstByteOfRecord == MARKER_RECORD_DELETED, recordValues);        
     }
 
     /**


### PR DESCRIPTION
Improved performance when reading hundreds of thousands of records at once by buffering raw data into a byte array.